### PR TITLE
11 ebs no snapshot issue

### DIFF
--- a/services/ec2/drivers/ec2_ebs.class.php
+++ b/services/ec2/drivers/ec2_ebs.class.php
@@ -46,7 +46,7 @@ class ec2_ebs extends evaluator{
         return;
     }
     
-    function __checkOutdatedSnapshot(){
+    function __checkSnapshot(){
         $block = $this->block;
         $volumeId = $block['VolumeId'];
         

--- a/services/ec2/drivers/ec2_ebs.class.php
+++ b/services/ec2/drivers/ec2_ebs.class.php
@@ -46,18 +46,6 @@ class ec2_ebs extends evaluator{
         return;
     }
     
-    function __checkSnapshotBlock(){
-        $block = $this->block;
-        
-        if($block['SnapshotId']){
-            $this->results['EBSSnapshot'] = [1, $block['SnapshotId']];
-        }else{
-            $this->results['EBSSnapshot'] = [-1, $block['SnapshotId']];
-        }
-        
-        return;
-    }
-    
     function __checkOutdatedSnapshot(){
         $block = $this->block;
         $volumeId = $block['VolumeId'];
@@ -82,6 +70,8 @@ class ec2_ebs extends evaluator{
             }
             
             $this->results['EBSUpToDateSnapshot'] = [-1, ''];
+        }else{
+            $this->results['EBSSnapshot'] = [-1, $block['SnapshotId']];
         }
         
         return;


### PR DESCRIPTION
# Description

Fix issue that EBS no snapshots wrong parameter checked. Previously EBS without snapshot will not be listed in the findings. Consolidate No Snapshot and Snapshot outdated checking into 1 function

Fixes #11 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Execute Service Screener in environment that consists of EBS without snapshot.
2. Verify findings and ensure EBS is detected in EBS no snapshot item.

Test Configuration:
Platform: AWS CloudShell
Region: ap-southeast-1
PHP version: 7.2
AWS SDK version: 3.0
Browser (to display output): chrome

# Checklist:
Test Configuration:
Platform: AWS CloudShell
Region: ap-southeast-1
PHP version: 7.2
AWS SDK version: 3.0
Browser (to display output): chrome

- [/] My code follows the style guidelines of this project
- [/] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [/] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with all regions and services
- [ ] Any dependent changes have been merged and published in downstream modules
