### PR TITLE
Comp opt api not available

### DIFF
--- a/services/ec2/drivers/ec2_compopt.class.php
+++ b/services/ec2/drivers/ec2_compopt.class.php
@@ -9,11 +9,25 @@ class ec2_compopt extends evaluator{
     
     function __checkComputeOptimizerEnabled(){
         $compOptClient = $this->compOptClient;
-        $result = $compOptClient ->getEnrollmentStatus();
         
-        if($result['status'] != 'Active'){
-            $this->results['ComputeOptimizerEnabled'] = [-1, $result['status']];
+        
+        ## User SSM to check service exist
+        // /aws/service/global-infrastructure/regions/ap-southeast-1/services/compute-optimizer
+        
+        try{
+            $result = $compOptClient ->getEnrollmentStatus();
+            if($result['status'] != 'Active'){
+                $this->results['ComputeOptimizerEnabled'] = [-1, $result['status']];
+            }
+        }catch(Exception $e){
+            
+            print_r('start');
+            print_r($e->getCode());
+            print_r('end');
         }
+        
+        
+        
         
         return;
     }

--- a/services/ec2/drivers/ec2_compopt.class.php
+++ b/services/ec2/drivers/ec2_compopt.class.php
@@ -10,24 +10,10 @@ class ec2_compopt extends evaluator{
     function __checkComputeOptimizerEnabled(){
         $compOptClient = $this->compOptClient;
         
-        
-        ## User SSM to check service exist
-        // /aws/service/global-infrastructure/regions/ap-southeast-1/services/compute-optimizer
-        
-        try{
-            $result = $compOptClient ->getEnrollmentStatus();
-            if($result['status'] != 'Active'){
-                $this->results['ComputeOptimizerEnabled'] = [-1, $result['status']];
-            }
-        }catch(Exception $e){
-            
-            print_r('start');
-            print_r($e->getCode());
-            print_r('end');
+        $result = $compOptClient ->getEnrollmentStatus();
+        if($result['status'] != 'Active'){
+            $this->results['ComputeOptimizerEnabled'] = [-1, $result['status']];
         }
-        
-        
-        
         
         return;
     }

--- a/services/ec2/ec2.class.php
+++ b/services/ec2/ec2.class.php
@@ -186,11 +186,11 @@ class ec2 extends service{
         // $this->ssmClient->
         $region = $this->__AWS_OPTIONS['region'];
         $compOptPath = "/aws/service/global-infrastructure/regions/".$region."/services/compute-optimizer";
-        $result = $this->ssmClient->getParametersByPath([
+        $compOptCheck = $this->ssmClient->getParametersByPath([
             'Path' => $compOptPath
         ]);
         
-        if(isset($result['Parameters']) && sizeof($result['Parameters']) > 0){
+        if(isset($compOptCheck['Parameters']) && sizeof($compOptCheck['Parameters']) > 0){
             $driver = 'ec2_compopt';
             if (class_exists($driver)){
                 __info('... (Compute Optimizer) inspecting');

--- a/services/ec2/ec2.class.php
+++ b/services/ec2/ec2.class.php
@@ -7,6 +7,7 @@ use Aws\ElasticLoadBalancingV2\ElasticLoadBalancingV2Client;
 use Aws\ElasticLoadBalancing\ElasticLoadBalancingClient;
 use Aws\AutoScaling\AutoScalingClient;
 use Aws\CostExplorer\CostExplorerClient;
+use Aws\Ssm\SsmClient;
 
 class ec2 extends service{
     const EC2_SDK_VERSION = '2016-11-15';
@@ -15,6 +16,7 @@ class ec2 extends service{
     public $elbClient;
     public $elbClassicClient;
     public $asgClient;
+    public $ssmClient;
     
     function __construct($region){
         parent::__construct($region);
@@ -36,6 +38,9 @@ class ec2 extends service{
         
         $this->__AWS_OPTIONS['version'] = CONFIG::AWS_SDK['COSTEXPLORERCLIENT_VERS'];
         $this->costExplorerClient = new CostExplorerClient($this->__AWS_OPTIONS);
+        
+        $this->__AWS_OPTIONS['version'] = CONFIG::AWS_SDK['SSMCLIENT_VERS'];
+        $this->ssmClient = new SsmClient($this->__AWS_OPTIONS);
         
         $this->__loadDrivers();
     }
@@ -176,6 +181,18 @@ class ec2 extends service{
     function advise(){
         $objs = [];
         $securityGroups = [];
+        
+        ## Check Compute Optimize available for the region
+        // $this->ssmClient->
+        $region = $this->__AWS_OPTIONS['region'];
+        $compOptPath = "/aws/service/global-infrastructure/regions/".$region."/services/compute-optimizer";
+        $result = $this->ssmClient->getParametersByPath([
+            'Path' => $compOptPath
+        ]);
+        
+        if(isset($result['Parameters']) && sizeof($result['Parameters']) > 0){
+            print_r('ComputeOptimizer Exist');
+        }
         
         $driver = 'ec2_compopt';
         if (class_exists($driver)){

--- a/services/ec2/ec2.class.php
+++ b/services/ec2/ec2.class.php
@@ -191,17 +191,15 @@ class ec2 extends service{
         ]);
         
         if(isset($result['Parameters']) && sizeof($result['Parameters']) > 0){
-            print_r('ComputeOptimizer Exist');
-        }
-        
-        $driver = 'ec2_compopt';
-        if (class_exists($driver)){
-            __info('... (Compute Optimizer) inspecting');
-            $obj = new $driver($this->compOptClient);
-            $obj->run();
-            
-            $objs['ComputeOptimizer'] = $obj->getInfo();
-            unset($obj);
+            $driver = 'ec2_compopt';
+            if (class_exists($driver)){
+                __info('... (Compute Optimizer) inspecting');
+                $obj = new $driver($this->compOptClient);
+                $obj->run();
+                
+                $objs['ComputeOptimizer'] = $obj->getInfo();
+                unset($obj);
+            }
         }
         
         $driver = 'ec2_costExplorer';

--- a/tools/config.php
+++ b/tools/config.php
@@ -16,6 +16,7 @@ class Config{
         'S3CONTROL_VERS' => '2018-08-20',
         'STSCLIENT_VERS' => '2011-06-15',
         'CLOUDWATCHCLIENT_VERS' => '2010-08-01',
+        'SSMCLIENT_VERS' => '2014-11-06',
         'signature_version' => 'v4'
     ];
     


### PR DESCRIPTION
# Description

User hit error while scanning EC2 service in region that ComputeOptimizer is not allowed. Use SSM Client to check whether API path for ComputeOptimizer exist or not.

Fixes # (issue)
#6 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Execute scanning for EC2 service to ensure no error is shown in region that ComputeOptimzer is not allowed.

**Test Configuration**:
* Firmware version: AWS Cloud9
* Region: ap-east-1
* PHP-version: 7.2
* SDK: 3.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with all regions and services
- [ ] Any dependent changes have been merged and published in downstream modules
