### PR TITLE
Standardize Instance Info Extraction

### DIFF
--- a/services/rds/drivers/rds_common.class.php
+++ b/services/rds/drivers/rds_common.class.php
@@ -193,8 +193,9 @@ class rds_common extends evaluator{
         }
         
         $dbInstClass = explode('.', $this->db['DBInstanceClass']);
-        $dbInstFamily = $dbInstClass[1][0];
-        $dbInstGeneration = $dbInstClass[1][1];
+        $instInfo = __aws_parseInstanceFamily($this->db['DBInstanceClass']);
+        $dbInstFamily = $instInfo['prefixDetail']['family'];
+        $dbInstGeneration = $instInfo['prefixDetail']['version'];
         
         if($dbInstFamily == 't'){
             $this->results['BurstableInstance'] = [-1, $this->db['DBInstanceClass']];   

--- a/tools/__load.php
+++ b/tools/__load.php
@@ -67,3 +67,38 @@ function __formatException($e){
     
     return implode('', $msg);
 }
+
+function __aws_parseInstanceFamily($instanceFamilyInString){
+    $arr = explode('.', $instanceFamilyInString);
+    if(sizeof($arr) > 3 || sizeof($arr) == 1){
+        return $instanceFamilyInString;
+    }
+    
+    if(sizeof($arr) == 3 && strtolower($arr[0]) =="db"){
+        $p = $arr[1];
+        $s = $arr[2];
+    }else{
+        $p = $arr[0];
+        $s = $arr[1];
+    }
+    
+    $patterns = "/([a-zA-Z]+)(\d+)([a-zA-Z]*)/i";
+        $result = preg_match(
+        $patterns, 
+        $p, 
+        $output
+    );
+    
+    $result = [
+        "full" => $instanceFamilyInString,
+        "prefix" => $p,
+        "suffix" => $s,
+        "prefixDetail" => [
+            "family" => $output[1],
+            "version" => $output[2],
+            "attributes" => $output[3]
+        ]
+    ];
+    
+    return $result;
+}


### PR DESCRIPTION
# Description
Majority of the services required to check if it is using the latest version. Create a standard function to perform the task.

Fixes # (issue)
## Type of change
- [o] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
testArr = [
    "a61gn.12xlarge",
    "db.r6g.2xlarge",
    "c4.xlarge",
    "t2.nano",
    "t1.medium",
    "m6g.2xlarge.search",
    "whatIsThis"
];

foreach($testArr as $str){
    print_r(__aws_parseInstanceFamily($str));
}

**Test Configuration**:
Cloudshell, PHP 8.0

# Checklist:
- [o] My code follows the style guidelines of this project
- [o] I have performed a self-review of my own code
- [o] My changes generate no new warnings
- [o] I have tested this change with single region and single services
