### PR TITLE
Fix exception errors where GD produce no findings

### DIFF
--- a/services/guardduty/guardduty.pageBuilder.php
+++ b/services/guardduty/guardduty.pageBuilder.php
@@ -238,9 +238,11 @@ class guarddutyPageBuilder extends pageBuilder{
         if(!empty($__l)) $tab[] = $this->__buildFindingsList('Low Severity', $__l);
         
         # $tab[] = $this->__buildFindingsList($title, $items);
-        
-        $html = implode('', $tab);
-        unset($tab);
+        $html = 'No findings';
+        if(!empty($tab)){
+            $html = implode('', $tab);
+            unset($tab);
+        }
         
         $card = $this->generateCard($id=$this->getHtmlId('findings'), $html, $cardClass='alert', $title='All findings', '', $collapse=true);
         $items[] = [$card, ''];


### PR DESCRIPTION
# Description
Fix exception errors where GD produce no findings

Fixes # (issue)
- [o] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Cloudshell and Cloud9, where the region does not support GuardDuty, or GuardDuty has 0 finding.

# Checklist:
- [o] I have performed a self-review of my own code
- [o] My changes generate no new warnings

